### PR TITLE
Temporarily remove FPU context switch as a workaround for newer kernel versions.

### DIFF
--- a/uapi.c
+++ b/uapi.c
@@ -177,17 +177,11 @@ struct code_runner_task {
 static void code_runner_sched_in(struct preempt_notifier *notifier, int cpu) {
     struct execution_engine *ee = container_of(notifier, struct execution_engine, preempt_notifier);
     ee->preempt_in_count++;
-    kernel_fpu_begin();
-    fpu__restore(&current->thread.fpu);
-    preempt_enable();
 }
 
 static void code_runner_sched_out(struct preempt_notifier *notifier, struct task_struct *next) {
     struct execution_engine *ee = container_of(notifier, struct execution_engine, preempt_notifier);
     ee->preempt_out_count++;
-    preempt_disable();
-    fpu__save(&current->thread.fpu);
-    kernel_fpu_end();
 }
 
 static struct preempt_ops code_runner_preempt_ops = {


### PR DESCRIPTION
`fpu__restore` is removed in newer kernels: https://lore.kernel.org/patchwork/patch/1053309/

Floating point support for kernel mode should also be disabled in the main wasmer binary.