### PR TITLE
Fix backtick escaping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then just run `make` in the root directory, and (optionally) `networking` and `w
 make
 ```
 
-Install the modules into `/lib/modules/\`uname -r\`/extra`
+Install the modules into ``/lib/modules/`uname -r`/extra``
 
 ```
 make install


### PR DESCRIPTION
To escape backticks-in-backticks, switch the outer/container backticks to double-backticks.  (See: https://github.com/github/markup/issues/363#issuecomment-200097074 .)